### PR TITLE
Add draw.io SVG event modeling template

### DIFF
--- a/content/event-modeling.drawio.svg
+++ b/content/event-modeling.drawio.svg
@@ -1,0 +1,768 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1962px" height="3835px" viewBox="-0.5 -0.5 1962 3835" content="&lt;mxfile host=&quot;&quot; modified=&quot;2020-06-01T23:14:50.782Z&quot; agent=&quot;5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Code-Insiders/1.46.0-insider Chrome/78.0.3904.130 Electron/7.3.0 Safari/537.36&quot; etag=&quot;OgNbvvCKDXQsnFfeuUFY&quot; version=&quot;13.1.3&quot;&gt;&lt;diagram id=&quot;6hGFLwfOUW9BJ-s0fimq&quot; name=&quot;Event Modeling&quot;&gt;7V1bd+K4k/80Obv78M/xDUIeCZC052DTGchk4GWPMMIYfGF9Acyn3yrJNhebQE8w6el20jQgy1LdJFX9Slbu5JazefHJcqZ5E2rfScJkcye37yRJfJQe4Q1L4qREkJMS07cmSdmuoG9taVoxKY2sCQ0OKoaeZ4fW8rDQ8FyXGuFBGfF9b31YberZh70uiUlzBX2D2PnSd2sSznipLAvC7sI3apmzpGul3khuGRNjYfpe5CYd3knylP3yyw5JG0taCmZk4q33iuTOndzyPS/kn5xNi9oo3VRu/L7nE1cTKlbEjhJWBtRZ2iSkSXdhnPJoe8aC4m3infyUsuVTN7ykHynXT5eaFJg+7oWJgnUjQDfrmRXS/pIYeHUNxgNls9CxEyqmlm23PNvz2b0yrcNvDcqD0PcWdO9Kpw6/eGXqueFeOf+B8hX1Qwv02bQt04VrobdMavcT2sT0Ozc+lHwiBbyXbo4MYScYMdMS2D/1HBr6MVRJbmgkeo0Pv653ViTWk7LZvgGllkUSyzWzlndagA+JIoqVouSU8jl1ZLYpFMgqp5OG0qg1akdadD2XZpXToXQlUV8i64fShF3LCbsf0iWUgOSa8PbkE8sNQs93LNfM6QG4Do+EfSDPRG4FoiSJRdt0GhYYumNNJthJoW4Ptf+heo8GVqbcEvRWy+sNZtq82qQraE2Wz48RnL6XJ/lMlhwyTqsLP8r/Eft1scBuHwvtVr6CBMS84ZYgAS7nvAhuxGP9N16easWST6xNvuWCJDZ+uRXphHTTqU04HNtF0i5vSRIfT61JEl+TBjNwA4XvNjiXv9mCdKHabrIEXeCm3XgJEsWHm65B8m3WIOUr1yAlPxjL4PGEYd9Ij7/xOsv1+3Oss/LDr7bOnpLuT7HOynm3Jlln5f11tg/BH9L85BE/PyJ+7QX3Uv3dYsGt5Rfc32aW+jE3IBsy52at+lUQlAu8gH/XrPVjuEexuAunrevIO79aJ9OWwqctdQKcWFMkWXWXURj8ZpPWj6qvYNUpbRJ7zCsvp50bRw0wyV8aNdSv4W2mMUq5IuCC/gce9XV4zCdwSuDxQfhSHqWb8HjClm/E401wZi7JL+PxN/arHk7g2z8Y/V1lXX/45fyoU9L9bPR3HXGfdKNqOTeqF4W/oR91qfpu4jddAI3c2G+SizKeJc7TjxdkYa7gNz185Vr0eBO0lUvyq3gU03FTMpMnoJtbMXkTDziR5ddxmfeBfxvfKVHxz+E8icIFnvq/y3s6Kd+fwn0ShXzYkPhPde4/NZdLG8ltee6axP8F3pPQJeucUn5tH+piJd7Cicp7vKoLwo6M0PJc1E+29e1YSZ/aZCreBCg4gfdsUmftCPWT8nJ/UArkLjauIPi886qDuUHnmF+akRW+EXhNLT8I4R1tEz4Rd8I2HQreFOuxW7zIR8nFQUgdJpnIhsVGGFNs5p7FKljB9AgjALUaelhAw6QTw3Mczy3oheCytbtsE9eMcIN1QmewpGQBPdRtHG1j6KVuhswcjku+25QEeAsETfA/DC1sjzCR0BVojFE1IyEjHP7zqU1XxMXvlrtj0qAu8S0Pueqkt4HG2c1A8l4rM7JcUpdO0gZClrlbkiDEmwcz6tOp52esuMTBNyvrEGvibdQNmBCfPSSAboizRJPD6QyY+78It3M/9XyQG95kw5Qy2ZVfJBt4h0bhgzsOluy7cFlRJlTbchjhMUgpoPY01TDn+Vi+BomC1LyMGaiUpvYEmg+R2astkrlFsV5rjI2HwhWwYDrfm3fF+gfz7plpn3s4AZCMVi23GxdP1dJZV7K8GeKCuAdkvcSPlsOeesgY75Ixtb97gYWzOFwfe2HoOVDBxgtP2YMMe7Kcsp+TwiMw1NnTGFNrg5bwxLpspqVCWgKfJyQkMD74V+k5WMFE8rQB+5Ba37/p0ih+Usbvm8jYChb59qdgtL1VV57Ik7gma3FtZTjGSps311rrcTtxDEt9eY7JeyckL/Zi9PJX9L3/h2C4f9mq9eSMJV00pGdr/PL2qDqj2fibjuWL4d9/zrp/P8Wj99GStgVr5DzHWfm7PR9LCtTfLEfSTBi6fwVDSzWH0mZmyNqj6iKN4nIM18fOW9h9H83UlxHct1//yRn2Rbk76Gyg3XgsbWygazl+B3q/jZajvyetsWw+qvOmqbWaW32gmvqgE6tzpWG8PAuk9eSQ900A98wnf/8BdNaEV+kxGMsq8Pv6qC6Ejb4dmr3207w7eIu784WgtpthbzA09bYWae0h+4wvaF/pzk24bkQafs9eoy28h3qsbHSrCS9o09HW3YEmdueaqc3NSN+qoT5/NeHF3nstRdFbzbXa7kjdQdZeiG0l38Pda1QfDBZSd96U1Par2OtDP5IG9wJ9g7eoN9BM3VJizWoC/UNFbZtRr/1noM1fI5CFqW2H+H2uWUpNj5tCd/4qIQ+9gWEymlvNjRYrW7hf7s47AmkbyKc43L5FcC/yvdFayhb4StrvbIGvmNOZ9RNm/fQVWW+xurHaViN9boQ6lPHPZsh4f1mDbN9CJuPBTAX5wvc/AuAR5PsK7XcUmuhG62hgr4oM9AHPTdCVymhHuvTtaA7vgo70xSh7RdD7TZAt9NFvCnCfiDpBOelbE2Ucofy1AchosAAdA01b0At+bzVFkJEA/dTgfaO7SNPI09szqQsy1xwtBPo23QHwuzXgswEyWHDesX4f6G0paz0WQO9vNbBZkKcJ9VWQhQl1hyB7A2x5CN87aNNr0KUE9WOQr4gyA3qBZmELMgRaBFGLWbv4XdL6AvIFfQgRXEOZSKA7MWljA3YGfKnQ50KEtmPgR8Z2e9zO8Luox4y/tK6C8tS2TZQn2Fkn0piNwnfQjbbtgKzeQN6voKNX+L6A9w7IDPifd0IdZdlWYWxAvTboeK5GWh/aboNM2qMZlIFsmqD3V6DpDeTC9acx21DBNjogDx3s+jmV8Vp/12poYzB20MbgXhxDYI8Dg9mE2sYx+opyRxlKr1ttC7Ylgq7jhG7g5w3tLta4TbA5QRsYEraFNo72B9dRfjGjh117qqtWA+bP73w2hE+fXbtS5PLI9xXzkeJjQcjxcF+vfX5pK3iYjT1qyJ3OckKOIjCAe2LoVRx0lHpveOE/AfM/0N0TG8vN7mLqvTE3NG0KuuetpZ7dpzypY+fp+fGxo7TyYND08ZEqRhEmkfpi4qVWcwbvFoXaod0UIQxigUdUu4JDlDpAZ4PVvKP0uScib5LxlT4er8fRar3gmbhCX/QarmjB84c8WuUBRkiCxUFkafiUPZfKQgyIiaLAQtZRYnzjpEMmWdABbQS7MAVDrX4Su8QsuPMxQsnCOMLCHZdmwSnc5seey2PGlUXXPNLhxFgOTSozunbh7S4aSqo6ZEHxPcB4j4srHznxmDILSTHoq6KlnQWffzKsPAvNA1n5FeXK84JYlICslpScWXwMwx0vKfWirWdlLSnp8nWowgOcZZDNIcf4y4lgfGrTTRNPKoBK1J0kH9uGTYLAOhKpWIAmC+wnr5Ks/HQQ/8x+c6N3vTdvAEXpNFK7lw9/+OWENOVeUY6v7llSOokYoGfqZ/Kgk9zxC+ctYU/TtQ8U7VObhNbqsP0i7Sc9fPcsNgpTQxMPDe3h4ciAAi/yDZrctT/ujxqShDMNhcQ3aZhrCCyBxHvVllgh+IDgenE/O9vmLe4sPZPpZcafR5iK/Sn5uvOmUjToru5PyR8/p5BH/5UbOlRKPgDSMekltTKnam35dOoTh3klDHt2QOjRMtjzm/Y8Kg6Cu5ROmK/E3B0ymfg04P6LF9CdH8Mrr6wgYikBmxLfBccIfS+NY+KWs/R8cJRCzNchUZQYsztMR1CWXHCiYA+qX0I3OA/glcDb963w+hh4XPrctKeMk4T0NGMxI8GukA3CzLub0CC0XMJwzAO+LReactILhyRMfc/JKkYB9VmmcQkcIlxprSqIe+9xnvO7JcobBfmALu+0XXnyqd9kE4rycTAnCseTT9G+sSKnRxavIfcKC7lkaNQv2GdelmOqFD1KXjmmJTmmF2i6TMf0cDJoCPfC3k+KPv2ol3o8x5xp9ko+a/2406t6rEp+P/x33zPAx0G34oTZXyE5mpnvL5oc3eaTo/pqFF+SFMV6WTJUuiAZKmo/ngwVepi0aTW3LGEmrUOWILOEWG8p0nD7GmkxS1LFapt9FjCp0x0Y6+78j+C4bq+PiR6TJRm7AxOuNTExFrJkEiab+gImb6TuAJOlQ0yWhTom12Khhm1AedRrCUJ33oH6TUwiQjuYNDIx4bYdtDVFY8mczkZ70aCOgX1uoJ4A9yqsr7mBdEpYjydkn9+1+VvUe8E+35DebXe+wPYjvS/UunNOG9Cw1S1FRrox2YYJRkx4Aj0swYXJSHZ/v7npztWwB32q7SHyhG2YrA1xKOvvQBcmxlhydcHk2Ws1N1Af6BmuUT4aJlrf1kqvhUlSE2j8a45JxkR+SE+o9ZVawruJvHcHKiYTTW0+RFox0Smp7TeF9cFk2ExkiLyg3F8jlgjto+443XpnLYFutixZBnQij/B5i/zwz68yJsj0bTPSnNQWmly/MeplgbQoLBHcx+T4EHUkYmIPdQJ6Y7zBPVuwR+wLE3iM7t6A0bNl9tFSNlB/jXRhAlHnCbpIk9YCtC9xXkdzrt8m06/aZvo1uX6bErcDpl9JR/04GmuP9wF0Mv02d7rBxKDF5M10w/k1mG5S/XI5Cahfs8dsCvXb3NmIDPzyvmKgkyXEe5h0ZjLp1BhvmJRsMTvfjNuvmBQ3WcLc0TL5oazgxXljdqoiTyhnsD9VQnlhohxsVQQbqSUyDBMZbtDOUe7dvsI2SnTnWsjHFdrLc30wUEWmg+0I7UpgemkJMHYYXWBX5hpfxhbltwh7LMneTN+ZDoE2BTdApPeA3Ng9+E4tdfV9vl4Z8sj9jh4H+/c51y9FgJQj9z3vvdelvL+Qln3KMcwD3W8B23umor8zRQf6eCXc847KWwQPguIJCWa7rbQHcXASQLOl2dmYeMzsveUFD/eOFRj31nK2v0N6r3tDwN/zQfRHjusJ3/BzxiAfonRFm67LCqBr+QxEMYKnXDeIrt3kuaPaieeOTiF4jYKN06VhF7U8ePq8DztR4tsWG5cBNRKUiu+ZJesdQLZOQbu7BLIL+Jbe2W4vMHUJz53u4Ky0crZ5M4UCedJ1Hx1kEBvbLcvxO8yIMnANW+bROs/bIo7IyJhEWbqUJP2xTbYJE62ULgg9FztG9rabvqnw3zi+220tPsi3IofY4HpPAhyPhPgj5NDPAYAXGD6lPN96x4BJ2zKskLIHCZKKBog6wS24CCwUgRUy3I+wXsb4aYn3MsywQgB3w+z8o2+ljaI0XPwQAbzy5NXI91nC5FU/gaueQgAbRWfFFqFLVznnql4hgJcMjcYFjxKWhQDWKwTwhgjgBZquEMCfAAGsVwhghQBWCGCFAFYIYIUAlokAnnIIvh4BrFcI4K0RwDPG8IUIYL2sPcitFLe5RSgn11pKp5GPK+SaodBGqaFcelLGpRtwrhHaPVwK29Zycv4U8vFwE9j24cdgW6lWcFZuaYDTQx62bZqEPc5he96C4074l96wHxw+XnZ2Auplf/vi3rbGDBR1OXrLj29gmGgCkx5uVySGETkR/u02BEYZVor4K+89e+gkIQN6OAJXVxZh//NnXf6bLAgLQcnkPw6CZ8H/JCccsC2fDovexgdHJNjWIjsAgNgQWBM/afBu7zGbmReyv/6X7dNMQWuLiTSBqjldZEUsWDgsO7RC7I9h0L7nORzqpWmbCXzNIOedwBmDY/ia1MIbK4R2N6K+EKFt5PdL5hHaK89TonCTM98a5551PJ6oiv6USiFEe/xAwD8SfAXRXjI2Elv5Goy2UWG0N8RoL1H1LUHawwb+OSp72M6/AoZtVDBsBcNWMGwFw1YwbAXDlgnDnlzzvx6HbVQ47K1x2HPW8IVAbKMCYj+pw69AYh8LA7graO1PSjKV7U76ZMjJ6SNBy9VtW+nIELDmdDtRaFJeum6Vgum5NN1mB4uchdnrOUl/Er66zV/0Ej7+08fHQLssF0i/+PjSa5wsLQqnjjje3/u8cPf2Ox+C5BAFB3cpHM12EHvs7GAGLR+eeZzh7wbb2BxADJ1tSrYTWJnd6pvEtbYJ6Hx8OC51AmqvKO+U78ZeW45NXMpORng/3qs94bD87tgrYtt7kPgONsdrdGOxExNIuiU5oBkzJAo913O8KOAq3j9yKqBQwDc1h5QwOJ0z6a1dDvOz/lnXbB83xLoWrK7bVIys9+zgqmxftw2M20fKAKuDSYMpEcYJm8E4gVNoPjl2eqcCzqXhOcvUeUkvIJ3sHC+KNdLZjaUUfDo9mExnYbhk8+gz2hO1DXYy/L2B27qfv3m4Wf2ZnxYf/G+XrO/ZBFewRh6eJ59Np2Q3l/I0i8aY5vWrDMPeXHL+aJ4yp4p8YjKfZLj2LC0WnQRRAex50ziRfTqBZ8ryLc+EFAv/kkAFwZcGwZ9PRZZ6hNeRrSnHx6FcfobXuZaudojXiY6uBcWLYj5RWGHxFRZfYfEVFl9h8RUWf00s/owneATGy0oBlFcWGi+KeSivguPLhuPPGMQRHi8XbfUsC5DPjnutEPlrR3hFZ8+XGOEVoakVRn8zbT+UmJC5w0MzUCm74AfnPa4DufP/&lt;/diagram&gt;&lt;/mxfile&gt;" style="background-color: rgb(243, 243, 243);">
+    <defs/>
+    <g>
+        <rect x="0" y="33" width="160" height="400" fill="#e6e6e5" stroke="#e6e6e5" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 158px; height: 1px; padding-top: 40px; margin-left: 1px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #333333; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Legend
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="80" y="62" fill="#333333" font-family="Helvetica" font-size="22px" text-anchor="middle" font-weight="bold">
+                    Legend
+                </text>
+            </switch>
+        </g>
+        <rect x="200" y="33" width="1760" height="400" fill="none" stroke="#848585" stroke-width="2" pointer-events="all"/>
+        <rect x="200" y="3" width="330" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 328px; height: 1px; padding-top: 13px; margin-left: 202px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #848585; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Step 1: Brainstorming
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="202" y="20" fill="#848585" font-family="Helvetica" font-size="22px">
+                    Step 1: Brainstorming
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="593" width="160" height="400" fill="#e6e6e5" stroke="#e6e6e5" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 158px; height: 1px; padding-top: 600px; margin-left: 1px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #333333; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Legend
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="80" y="622" fill="#333333" font-family="Helvetica" font-size="22px" text-anchor="middle" font-weight="bold">
+                    Legend
+                </text>
+            </switch>
+        </g>
+        <rect x="200" y="593" width="1760" height="400" fill="none" stroke="#848585" stroke-width="2" pointer-events="all"/>
+        <rect x="200" y="563" width="330" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 328px; height: 1px; padding-top: 573px; margin-left: 202px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #848585; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Step 2: The Plot
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="202" y="580" fill="#848585" font-family="Helvetica" font-size="22px">
+                    Step 2: The Plot
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="1153" width="160" height="400" fill="#e6e6e5" stroke="#e6e6e5" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 158px; height: 1px; padding-top: 1160px; margin-left: 1px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #333333; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Legend
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="80" y="1182" fill="#333333" font-family="Helvetica" font-size="22px" text-anchor="middle" font-weight="bold">
+                    Legend
+                </text>
+            </switch>
+        </g>
+        <rect x="200" y="1153" width="1760" height="400" fill="none" stroke="#848585" stroke-width="2" pointer-events="all"/>
+        <rect x="200" y="1123" width="330" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 328px; height: 1px; padding-top: 1133px; margin-left: 202px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #848585; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Step 3: The Story Board
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="202" y="1140" fill="#848585" font-family="Helvetica" font-size="22px">
+                    Step 3: The Story Board
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="1713" width="160" height="600" fill="#e6e6e5" stroke="#e6e6e5" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 158px; height: 1px; padding-top: 1720px; margin-left: 1px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #333333; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Legend
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="80" y="1742" fill="#333333" font-family="Helvetica" font-size="22px" text-anchor="middle" font-weight="bold">
+                    Legend
+                </text>
+            </switch>
+        </g>
+        <rect x="200" y="1713" width="1760" height="600" fill="none" stroke="#848585" stroke-width="2" pointer-events="all"/>
+        <rect x="200" y="1683" width="330" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 328px; height: 1px; padding-top: 1693px; margin-left: 202px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #848585; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Step 4: Identify Inputs
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="202" y="1700" fill="#848585" font-family="Helvetica" font-size="22px">
+                    Step 4: Identify Inputs
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="2473" width="160" height="600" fill="#e6e6e5" stroke="#e6e6e5" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 158px; height: 1px; padding-top: 2480px; margin-left: 1px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #333333; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Legend
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="80" y="2502" fill="#333333" font-family="Helvetica" font-size="22px" text-anchor="middle" font-weight="bold">
+                    Legend
+                </text>
+            </switch>
+        </g>
+        <rect x="200" y="2473" width="1760" height="600" fill="none" stroke="#848585" stroke-width="2" pointer-events="all"/>
+        <rect x="200" y="2443" width="330" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 328px; height: 1px; padding-top: 2453px; margin-left: 202px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #848585; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Step 5: Identify Outputs
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="202" y="2460" fill="#848585" font-family="Helvetica" font-size="22px">
+                    Step 5: Identify Outputs
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="3233" width="160" height="600" fill="#e6e6e5" stroke="#e6e6e5" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 158px; height: 1px; padding-top: 3240px; margin-left: 1px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #333333; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Legend
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="80" y="3262" fill="#333333" font-family="Helvetica" font-size="22px" text-anchor="middle" font-weight="bold">
+                    Legend
+                </text>
+            </switch>
+        </g>
+        <rect x="200" y="3233" width="1760" height="600" fill="none" stroke="#848585" stroke-width="2" pointer-events="all"/>
+        <rect x="200" y="3203" width="330" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 328px; height: 1px; padding-top: 3213px; margin-left: 202px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #848585; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Step 6: Apply Conway's Law
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="202" y="3220" fill="#848585" font-family="Helvetica" font-size="22px">
+                    Step 6: Apply Conway's Law
+                </text>
+            </switch>
+        </g>
+        <rect x="240" y="73" width="740" height="180" fill="none" stroke="#658bc7" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 726px; height: 1px; padding-top: 86px; margin-left: 248px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: #848585; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Now we have a first understanding of how our system could behave. Our goal is to get a common understanding and common language we speak.
+                                <br/>
+                                <br/>
+                                Please put down all events that be relevant in our scenario. Events are things that happened in the past. Therefore we name it in past tense. For example: "Order placed".
+                                <br/>
+                                <br/>
+                                      Please limit yourself to the events that cause a change of state.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="248" y="102" fill="#848585" font-family="Helvetica" font-size="16px">
+                    Now we have a first understanding of how our system could behave. Our goal is to get a comm...
+                </text>
+            </switch>
+        </g>
+        <image x="247.5" y="193.5" width="19" height="27.65" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGFyaWEtaGlkZGVuPSJ0cnVlIiBmb2N1c2FibGU9ImZhbHNlIiBkYXRhLXByZWZpeD0iZmFyIiBkYXRhLWljb249ImxpZ2h0YnVsYiIgY2xhc3M9InN2Zy1pbmxpbmUtLWZhIGZhLWxpZ2h0YnVsYiBmYS13LTExIiByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAzNTIgNTEyIj48cGF0aCBmaWxsPSJjdXJyZW50Q29sb3IiIGQ9Ik0xNzYgODBjLTUyLjk0IDAtOTYgNDMuMDYtOTYgOTYgMCA4Ljg0IDcuMTYgMTYgMTYgMTZzMTYtNy4xNiAxNi0xNmMwLTM1LjMgMjguNzItNjQgNjQtNjQgOC44NCAwIDE2LTcuMTYgMTYtMTZzLTcuMTYtMTYtMTYtMTZ6TTk2LjA2IDQ1OS4xN2MwIDMuMTUuOTMgNi4yMiAyLjY4IDguODRsMjQuNTEgMzYuODRjMi45NyA0LjQ2IDcuOTcgNy4xNCAxMy4zMiA3LjE0aDc4Ljg1YzUuMzYgMCAxMC4zNi0yLjY4IDEzLjMyLTcuMTRsMjQuNTEtMzYuODRjMS43NC0yLjYyIDIuNjctNS43IDIuNjgtOC44NGwuMDUtNDMuMThIOTYuMDJsLjA0IDQzLjE4ek0xNzYgMEM3My43MiAwIDAgODIuOTcgMCAxNzZjMCA0NC4zNyAxNi40NSA4NC44NSA0My41NiAxMTUuNzggMTYuNjQgMTguOTkgNDIuNzQgNTguOCA1Mi40MiA5Mi4xNnYuMDZoNDh2LS4xMmMtLjAxLTQuNzctLjcyLTkuNTEtMi4xNS0xNC4wNy01LjU5LTE3LjgxLTIyLjgyLTY0Ljc3LTYyLjE3LTEwOS42Ny0yMC41NC0yMy40My0zMS41Mi01My4xNS0zMS42MS04NC4xNC0uMi03My42NCA1OS42Ny0xMjggMTI3Ljk1LTEyOCA3MC41OCAwIDEyOCA1Ny40MiAxMjggMTI4IDAgMzAuOTctMTEuMjQgNjAuODUtMzEuNjUgODQuMTQtMzkuMTEgNDQuNjEtNTYuNDIgOTEuNDctNjIuMSAxMDkuNDZhNDcuNTA3IDQ3LjUwNyAwIDAgMC0yLjIyIDE0LjN2LjFoNDh2LS4wNWM5LjY4LTMzLjM3IDM1Ljc4LTczLjE4IDUyLjQyLTkyLjE2QzMzNS41NSAyNjAuODUgMzUyIDIyMC4zNyAzNTIgMTc2IDM1MiA3OC44IDI3My4yIDAgMTc2IDB6Ii8+PC9zdmc+" preserveAspectRatio="none"/>
+        <rect x="25" y="83" width="110" height="50" fill="#000000" stroke="#000000" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="25" y="83" width="110" height="50" fill="#f99e4c" stroke="#f99e4c" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 108px; margin-left: 26px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                <font style="font-size: 18px">
+                                    Event
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="80" y="115" fill="#000000" font-family="Helvetica" font-size="22px" text-anchor="middle">
+                    Event
+                </text>
+            </switch>
+        </g>
+        <rect x="240" y="633" width="740" height="80" fill="none" stroke="#658bc7" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 726px; height: 1px; padding-top: 646px; margin-left: 248px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: #848585; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Now the task is to create a plausible story made of these events. So they arranged in a line and everyone reviews this timeline to understand that this makes sense as events that happen in order.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="248" y="662" fill="#848585" font-family="Helvetica" font-size="16px">
+                    Now the task is to create a plausible story made of these events. So they arranged in a lin...
+                </text>
+            </switch>
+        </g>
+        <rect x="25" y="643" width="110" height="50" fill="#000000" stroke="#000000" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="25" y="643" width="110" height="50" fill="#f99e4c" stroke="#f99e4c" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 668px; margin-left: 26px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                <font style="font-size: 18px">
+                                    Event
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="80" y="675" fill="#000000" font-family="Helvetica" font-size="22px" text-anchor="middle">
+                    Event
+                </text>
+            </switch>
+        </g>
+        <path d="M 35.5 724 L 35.5 722 L 85 722 L 110.17 722 L 110.17 718.83 L 124.5 723 L 110.17 727.17 L 110.17 724 L 85 724 Q 85 724 85 724 Z" fill="#000000" stroke="#000000" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 110.17 722 L 110.17 718.83 L 124.5 723 L 110.17 727.17 L 110.17 724" fill="none" stroke="#000000" stroke-linejoin="flat" stroke-miterlimit="4" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 723px; margin-left: 81px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #F3F3F3; white-space: nowrap; ">
+                                 Timeline 
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="81" y="727" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                     Timeline 
+                </text>
+            </switch>
+        </g>
+        <rect x="240" y="1193" width="740" height="80" fill="none" stroke="#658bc7" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 726px; height: 1px; padding-top: 1206px; margin-left: 248px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: #848585; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Next, the wireframes or mockups of the story are needed to address those that are visual learners. More importantly, each field must be represented so that the blueprint for the system has the source and destination of the information represented from the user's perspective.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="248" y="1222" fill="#848585" font-family="Helvetica" font-size="16px">
+                    Next, the wireframes or mockups of the story are needed to address those that are visual le...
+                </text>
+            </switch>
+        </g>
+        <rect x="20" y="1203" width="110" height="50" fill="#000000" stroke="#000000" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="20" y="1203" width="110" height="50" fill="#f99e4c" stroke="#f99e4c" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 1228px; margin-left: 21px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                <font style="font-size: 18px">
+                                    Event
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="1235" fill="#000000" font-family="Helvetica" font-size="22px" text-anchor="middle">
+                    Event
+                </text>
+            </switch>
+        </g>
+        <path d="M 30.5 1284 L 30.5 1282 L 80 1282 L 105.17 1282 L 105.17 1278.83 L 119.5 1283 L 105.17 1287.17 L 105.17 1284 L 80 1284 Q 80 1284 80 1284 Z" fill="#000000" stroke="#000000" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 105.17 1282 L 105.17 1278.83 L 119.5 1283 L 105.17 1287.17 L 105.17 1284" fill="none" stroke="#000000" stroke-linejoin="flat" stroke-miterlimit="4" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1283px; margin-left: 76px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #F3F3F3; white-space: nowrap; ">
+                                 Timeline 
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="76" y="1287" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                     Timeline 
+                </text>
+            </switch>
+        </g>
+        <image x="43.5" y="1322.5" width="62" height="62" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGFyaWEtaGlkZGVuPSJ0cnVlIiBmb2N1c2FibGU9ImZhbHNlIiBkYXRhLXByZWZpeD0iZmFzIiBkYXRhLWljb249ImNvZyIgY2xhc3M9InN2Zy1pbmxpbmUtLWZhIGZhLWNvZyBmYS13LTE2IiByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBmaWxsPSJjdXJyZW50Q29sb3IiIGQ9Ik00ODcuNCAzMTUuN2wtNDIuNi0yNC42YzQuMy0yMy4yIDQuMy00NyAwLTcwLjJsNDIuNi0yNC42YzQuOS0yLjggNy4xLTguNiA1LjUtMTQtMTEuMS0zNS42LTMwLTY3LjgtNTQuNy05NC42LTMuOC00LjEtMTAtNS4xLTE0LjgtMi4zTDM4MC44IDExMGMtMTcuOS0xNS40LTM4LjUtMjcuMy02MC44LTM1LjFWMjUuOGMwLTUuNi0zLjktMTAuNS05LjQtMTEuNy0zNi43LTguMi03NC4zLTcuOC0xMDkuMiAwLTUuNSAxLjItOS40IDYuMS05LjQgMTEuN1Y3NWMtMjIuMiA3LjktNDIuOCAxOS44LTYwLjggMzUuMUw4OC43IDg1LjVjLTQuOS0yLjgtMTEtMS45LTE0LjggMi4zLTI0LjcgMjYuNy00My42IDU4LjktNTQuNyA5NC42LTEuNyA1LjQuNiAxMS4yIDUuNSAxNEw2Ny4zIDIyMWMtNC4zIDIzLjItNC4zIDQ3IDAgNzAuMmwtNDIuNiAyNC42Yy00LjkgMi44LTcuMSA4LjYtNS41IDE0IDExLjEgMzUuNiAzMCA2Ny44IDU0LjcgOTQuNiAzLjggNC4xIDEwIDUuMSAxNC44IDIuM2w0Mi42LTI0LjZjMTcuOSAxNS40IDM4LjUgMjcuMyA2MC44IDM1LjF2NDkuMmMwIDUuNiAzLjkgMTAuNSA5LjQgMTEuNyAzNi43IDguMiA3NC4zIDcuOCAxMDkuMiAwIDUuNS0xLjIgOS40LTYuMSA5LjQtMTEuN3YtNDkuMmMyMi4yLTcuOSA0Mi44LTE5LjggNjAuOC0zNS4xbDQyLjYgMjQuNmM0LjkgMi44IDExIDEuOSAxNC44LTIuMyAyNC43LTI2LjcgNDMuNi01OC45IDU0LjctOTQuNiAxLjUtNS41LS43LTExLjMtNS42LTE0LjF6TTI1NiAzMzZjLTQ0LjEgMC04MC0zNS45LTgwLTgwczM1LjktODAgODAtODAgODAgMzUuOSA4MCA4MC0zNS45IDgwLTgwIDgweiIvPjwvc3ZnPg==" preserveAspectRatio="none"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
+            <rect fill="#F3F3F3" stroke="none" x="48" y="1393" width="56" height="15" stroke-width="0"/>
+            <text x="74.5" y="1402.5">
+                Processor
+            </text>
+        </g>
+        <path d="M 55 1438 C 55 1435.24 57.24 1433 60 1433 L 90 1433 C 92.76 1433 95 1435.24 95 1438 L 95 1508 C 95 1510.76 92.76 1513 90 1513 L 60 1513 C 57.24 1513 55 1510.76 55 1508 Z" fill="none" stroke="#c0c0c0" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="75" cy="1436.6" rx="0.5" ry="0.5" fill="none" stroke="#c0c0c0" pointer-events="all"/>
+        <rect x="57.5" y="1445" width="35" height="56" fill="none" stroke="#c0c0c0" pointer-events="all"/>
+        <path d="M 70 1439.8 C 70 1439.59 70.08 1439.38 70.23 1439.23 C 70.38 1439.08 70.59 1439 70.8 1439 L 79.2 1439 C 79.41 1439 79.62 1439.08 79.77 1439.23 C 79.92 1439.38 80 1439.59 80 1439.8 C 80 1440.24 79.64 1440.6 79.2 1440.6 L 70.8 1440.6 C 70.36 1440.6 70 1440.24 70 1439.8 Z" fill="none" stroke="#c0c0c0" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="75" cy="1507" rx="4" ry="4" fill="none" stroke="#c0c0c0" pointer-events="all"/>
+        <path d="M 73.3 1505.9 C 73.3 1505.62 73.52 1505.4 73.8 1505.4 L 76.2 1505.4 C 76.48 1505.4 76.7 1505.62 76.7 1505.9 L 76.7 1508.3 C 76.7 1508.58 76.48 1508.8 76.2 1508.8 L 73.8 1508.8 C 73.52 1508.8 73.3 1508.58 73.3 1508.3 Z" fill="none" stroke="#c0c0c0" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1520px; margin-left: 75px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #F3F3F3; white-space: nowrap; ">
+                                User Interface
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="1532" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    User I...
+                </text>
+            </switch>
+        </g>
+        <rect x="240" y="1753" width="740" height="80" fill="none" stroke="#658bc7" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 726px; height: 1px; padding-top: 1766px; margin-left: 248px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: #848585; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                From the earlier section we saw that we need to show how we enable the user to change the state of the system. Each time an event is stored due to a users action, we link that to the UI by a command that shows what we are getting from the screen or implicitely from client state if it's a web application.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="248" y="1782" fill="#848585" font-family="Helvetica" font-size="16px">
+                    From the earlier section we saw that we need to show how we enable the user to change the s...
+                </text>
+            </switch>
+        </g>
+        <rect x="20" y="1763" width="110" height="50" fill="#000000" stroke="#000000" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="20" y="1763" width="110" height="50" fill="#f99e4c" stroke="#f99e4c" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 1788px; margin-left: 21px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                <font style="font-size: 18px">
+                                    Event
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="1795" fill="#000000" font-family="Helvetica" font-size="22px" text-anchor="middle">
+                    Event
+                </text>
+            </switch>
+        </g>
+        <path d="M 30.5 1844 L 30.5 1842 L 80 1842 L 105.17 1842 L 105.17 1838.83 L 119.5 1843 L 105.17 1847.17 L 105.17 1844 L 80 1844 Q 80 1844 80 1844 Z" fill="#000000" stroke="#000000" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 105.17 1842 L 105.17 1838.83 L 119.5 1843 L 105.17 1847.17 L 105.17 1844" fill="none" stroke="#000000" stroke-linejoin="flat" stroke-miterlimit="4" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1843px; margin-left: 76px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #F3F3F3; white-space: nowrap; ">
+                                 Timeline 
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="76" y="1847" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                     Timeline 
+                </text>
+            </switch>
+        </g>
+        <image x="43.5" y="1882.5" width="62" height="62" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGFyaWEtaGlkZGVuPSJ0cnVlIiBmb2N1c2FibGU9ImZhbHNlIiBkYXRhLXByZWZpeD0iZmFzIiBkYXRhLWljb249ImNvZyIgY2xhc3M9InN2Zy1pbmxpbmUtLWZhIGZhLWNvZyBmYS13LTE2IiByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBmaWxsPSJjdXJyZW50Q29sb3IiIGQ9Ik00ODcuNCAzMTUuN2wtNDIuNi0yNC42YzQuMy0yMy4yIDQuMy00NyAwLTcwLjJsNDIuNi0yNC42YzQuOS0yLjggNy4xLTguNiA1LjUtMTQtMTEuMS0zNS42LTMwLTY3LjgtNTQuNy05NC42LTMuOC00LjEtMTAtNS4xLTE0LjgtMi4zTDM4MC44IDExMGMtMTcuOS0xNS40LTM4LjUtMjcuMy02MC44LTM1LjFWMjUuOGMwLTUuNi0zLjktMTAuNS05LjQtMTEuNy0zNi43LTguMi03NC4zLTcuOC0xMDkuMiAwLTUuNSAxLjItOS40IDYuMS05LjQgMTEuN1Y3NWMtMjIuMiA3LjktNDIuOCAxOS44LTYwLjggMzUuMUw4OC43IDg1LjVjLTQuOS0yLjgtMTEtMS45LTE0LjggMi4zLTI0LjcgMjYuNy00My42IDU4LjktNTQuNyA5NC42LTEuNyA1LjQuNiAxMS4yIDUuNSAxNEw2Ny4zIDIyMWMtNC4zIDIzLjItNC4zIDQ3IDAgNzAuMmwtNDIuNiAyNC42Yy00LjkgMi44LTcuMSA4LjYtNS41IDE0IDExLjEgMzUuNiAzMCA2Ny44IDU0LjcgOTQuNiAzLjggNC4xIDEwIDUuMSAxNC44IDIuM2w0Mi42LTI0LjZjMTcuOSAxNS40IDM4LjUgMjcuMyA2MC44IDM1LjF2NDkuMmMwIDUuNiAzLjkgMTAuNSA5LjQgMTEuNyAzNi43IDguMiA3NC4zIDcuOCAxMDkuMiAwIDUuNS0xLjIgOS40LTYuMSA5LjQtMTEuN3YtNDkuMmMyMi4yLTcuOSA0Mi44LTE5LjggNjAuOC0zNS4xbDQyLjYgMjQuNmM0LjkgMi44IDExIDEuOSAxNC44LTIuMyAyNC43LTI2LjcgNDMuNi01OC45IDU0LjctOTQuNiAxLjUtNS41LS43LTExLjMtNS42LTE0LjF6TTI1NiAzMzZjLTQ0LjEgMC04MC0zNS45LTgwLTgwczM1LjktODAgODAtODAgODAgMzUuOSA4MCA4MC0zNS45IDgwLTgwIDgweiIvPjwvc3ZnPg==" preserveAspectRatio="none"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
+            <rect fill="#F3F3F3" stroke="none" x="48" y="1953" width="56" height="15" stroke-width="0"/>
+            <text x="74.5" y="1962.5">
+                Processor
+            </text>
+        </g>
+        <path d="M 55 1998 C 55 1995.24 57.24 1993 60 1993 L 90 1993 C 92.76 1993 95 1995.24 95 1998 L 95 2068 C 95 2070.76 92.76 2073 90 2073 L 60 2073 C 57.24 2073 55 2070.76 55 2068 Z" fill="none" stroke="#c0c0c0" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="75" cy="1996.6" rx="0.5" ry="0.5" fill="none" stroke="#c0c0c0" pointer-events="all"/>
+        <rect x="57.5" y="2005" width="35" height="56" fill="none" stroke="#c0c0c0" pointer-events="all"/>
+        <path d="M 70 1999.8 C 70 1999.59 70.08 1999.38 70.23 1999.23 C 70.38 1999.08 70.59 1999 70.8 1999 L 79.2 1999 C 79.41 1999 79.62 1999.08 79.77 1999.23 C 79.92 1999.38 80 1999.59 80 1999.8 C 80 2000.24 79.64 2000.6 79.2 2000.6 L 70.8 2000.6 C 70.36 2000.6 70 2000.24 70 1999.8 Z" fill="none" stroke="#c0c0c0" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="75" cy="2067" rx="4" ry="4" fill="none" stroke="#c0c0c0" pointer-events="all"/>
+        <path d="M 73.3 2065.9 C 73.3 2065.62 73.52 2065.4 73.8 2065.4 L 76.2 2065.4 C 76.48 2065.4 76.7 2065.62 76.7 2065.9 L 76.7 2068.3 C 76.7 2068.58 76.48 2068.8 76.2 2068.8 L 73.8 2068.8 C 73.52 2068.8 73.3 2068.58 73.3 2068.3 Z" fill="none" stroke="#c0c0c0" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 2080px; margin-left: 75px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #F3F3F3; white-space: nowrap; ">
+                                User Interface
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="2092" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    User I...
+                </text>
+            </switch>
+        </g>
+        <rect x="20" y="2113" width="110" height="50" fill="#000000" stroke="#000000" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="20" y="2113" width="110" height="50" fill="#35c4e8" stroke="#35c4e8" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 2138px; margin-left: 21px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                <font style="font-size: 18px">
+                                    Command
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="2145" fill="#000000" font-family="Helvetica" font-size="22px" text-anchor="middle">
+                    Command
+                </text>
+            </switch>
+        </g>
+        <rect x="240" y="2513" width="740" height="80" fill="none" stroke="#658bc7" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 726px; height: 1px; padding-top: 2526px; margin-left: 248px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: #848585; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Again looking back at our goals for the blueprint, we now have to link information accumulated by storing events back into the UI via views (aka read-models). These may be things like a calendar view in a hotel system that will show the availabiltity of rooms when a user is looking to book a room.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="248" y="2542" fill="#848585" font-family="Helvetica" font-size="16px">
+                    Again looking back at our goals for the blueprint, we now have to link information accumula...
+                </text>
+            </switch>
+        </g>
+        <rect x="20" y="2523" width="110" height="50" fill="#000000" stroke="#000000" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="20" y="2523" width="110" height="50" fill="#f99e4c" stroke="#f99e4c" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 2548px; margin-left: 21px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                <font style="font-size: 18px">
+                                    Event
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="2555" fill="#000000" font-family="Helvetica" font-size="22px" text-anchor="middle">
+                    Event
+                </text>
+            </switch>
+        </g>
+        <path d="M 30.5 2604 L 30.5 2602 L 80 2602 L 105.17 2602 L 105.17 2598.83 L 119.5 2603 L 105.17 2607.17 L 105.17 2604 L 80 2604 Q 80 2604 80 2604 Z" fill="#000000" stroke="#000000" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 105.17 2602 L 105.17 2598.83 L 119.5 2603 L 105.17 2607.17 L 105.17 2604" fill="none" stroke="#000000" stroke-linejoin="flat" stroke-miterlimit="4" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 2603px; margin-left: 76px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #F3F3F3; white-space: nowrap; ">
+                                 Timeline 
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="76" y="2607" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                     Timeline 
+                </text>
+            </switch>
+        </g>
+        <image x="43.5" y="2642.5" width="62" height="62" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGFyaWEtaGlkZGVuPSJ0cnVlIiBmb2N1c2FibGU9ImZhbHNlIiBkYXRhLXByZWZpeD0iZmFzIiBkYXRhLWljb249ImNvZyIgY2xhc3M9InN2Zy1pbmxpbmUtLWZhIGZhLWNvZyBmYS13LTE2IiByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBmaWxsPSJjdXJyZW50Q29sb3IiIGQ9Ik00ODcuNCAzMTUuN2wtNDIuNi0yNC42YzQuMy0yMy4yIDQuMy00NyAwLTcwLjJsNDIuNi0yNC42YzQuOS0yLjggNy4xLTguNiA1LjUtMTQtMTEuMS0zNS42LTMwLTY3LjgtNTQuNy05NC42LTMuOC00LjEtMTAtNS4xLTE0LjgtMi4zTDM4MC44IDExMGMtMTcuOS0xNS40LTM4LjUtMjcuMy02MC44LTM1LjFWMjUuOGMwLTUuNi0zLjktMTAuNS05LjQtMTEuNy0zNi43LTguMi03NC4zLTcuOC0xMDkuMiAwLTUuNSAxLjItOS40IDYuMS05LjQgMTEuN1Y3NWMtMjIuMiA3LjktNDIuOCAxOS44LTYwLjggMzUuMUw4OC43IDg1LjVjLTQuOS0yLjgtMTEtMS45LTE0LjggMi4zLTI0LjcgMjYuNy00My42IDU4LjktNTQuNyA5NC42LTEuNyA1LjQuNiAxMS4yIDUuNSAxNEw2Ny4zIDIyMWMtNC4zIDIzLjItNC4zIDQ3IDAgNzAuMmwtNDIuNiAyNC42Yy00LjkgMi44LTcuMSA4LjYtNS41IDE0IDExLjEgMzUuNiAzMCA2Ny44IDU0LjcgOTQuNiAzLjggNC4xIDEwIDUuMSAxNC44IDIuM2w0Mi42LTI0LjZjMTcuOSAxNS40IDM4LjUgMjcuMyA2MC44IDM1LjF2NDkuMmMwIDUuNiAzLjkgMTAuNSA5LjQgMTEuNyAzNi43IDguMiA3NC4zIDcuOCAxMDkuMiAwIDUuNS0xLjIgOS40LTYuMSA5LjQtMTEuN3YtNDkuMmMyMi4yLTcuOSA0Mi44LTE5LjggNjAuOC0zNS4xbDQyLjYgMjQuNmM0LjkgMi44IDExIDEuOSAxNC44LTIuMyAyNC43LTI2LjcgNDMuNi01OC45IDU0LjctOTQuNiAxLjUtNS41LS43LTExLjMtNS42LTE0LjF6TTI1NiAzMzZjLTQ0LjEgMC04MC0zNS45LTgwLTgwczM1LjktODAgODAtODAgODAgMzUuOSA4MCA4MC0zNS45IDgwLTgwIDgweiIvPjwvc3ZnPg==" preserveAspectRatio="none"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
+            <rect fill="#F3F3F3" stroke="none" x="48" y="2713" width="56" height="15" stroke-width="0"/>
+            <text x="74.5" y="2722.5">
+                Processor
+            </text>
+        </g>
+        <path d="M 55 2758 C 55 2755.24 57.24 2753 60 2753 L 90 2753 C 92.76 2753 95 2755.24 95 2758 L 95 2828 C 95 2830.76 92.76 2833 90 2833 L 60 2833 C 57.24 2833 55 2830.76 55 2828 Z" fill="none" stroke="#c0c0c0" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="75" cy="2756.6" rx="0.5" ry="0.5" fill="none" stroke="#c0c0c0" pointer-events="all"/>
+        <rect x="57.5" y="2765" width="35" height="56" fill="none" stroke="#c0c0c0" pointer-events="all"/>
+        <path d="M 70 2759.8 C 70 2759.59 70.08 2759.38 70.23 2759.23 C 70.38 2759.08 70.59 2759 70.8 2759 L 79.2 2759 C 79.41 2759 79.62 2759.08 79.77 2759.23 C 79.92 2759.38 80 2759.59 80 2759.8 C 80 2760.24 79.64 2760.6 79.2 2760.6 L 70.8 2760.6 C 70.36 2760.6 70 2760.24 70 2759.8 Z" fill="none" stroke="#c0c0c0" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="75" cy="2827" rx="4" ry="4" fill="none" stroke="#c0c0c0" pointer-events="all"/>
+        <path d="M 73.3 2825.9 C 73.3 2825.62 73.52 2825.4 73.8 2825.4 L 76.2 2825.4 C 76.48 2825.4 76.7 2825.62 76.7 2825.9 L 76.7 2828.3 C 76.7 2828.58 76.48 2828.8 76.2 2828.8 L 73.8 2828.8 C 73.52 2828.8 73.3 2828.58 73.3 2828.3 Z" fill="none" stroke="#c0c0c0" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 2840px; margin-left: 75px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #F3F3F3; white-space: nowrap; ">
+                                User Interface
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="2852" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    User I...
+                </text>
+            </switch>
+        </g>
+        <rect x="20" y="2873" width="110" height="50" fill="#000000" stroke="#000000" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="20" y="2873" width="110" height="50" fill="#35c4e8" stroke="#35c4e8" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 2898px; margin-left: 21px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                <font style="font-size: 18px">
+                                    Command
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="2905" fill="#000000" font-family="Helvetica" font-size="22px" text-anchor="middle">
+                    Command
+                </text>
+            </switch>
+        </g>
+        <rect x="20" y="2943" width="110" height="50" fill="#000000" stroke="#000000" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="20" y="2943" width="110" height="50" fill="#d4e384" stroke="#d4e384" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 2968px; margin-left: 21px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                <font style="font-size: 18px">
+                                    Read
+                                    <br/>
+                                    Model
+                                    <br/>
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="2975" fill="#000000" font-family="Helvetica" font-size="22px" text-anchor="middle">
+                    Read...
+                </text>
+            </switch>
+        </g>
+        <rect x="240" y="3273" width="740" height="120" fill="none" stroke="#658bc7" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 726px; height: 1px; padding-top: 3286px; margin-left: 248px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: #848585; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Now that we know how information gets in and out of our system, we can start to look at organizing the events themselves into swimlanes. We need to do this to allow the system to exist as a set of autonomous parts that separate teams can own. This allows specialization to happen to a level that we control instead of falling out of the composition of teams. See 
+                                <a href="http://melconway.com/Home/Conways_Law.html">
+                                    Conway's Law
+                                </a>
+                                 by Mel Conway.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="248" y="3302" fill="#848585" font-family="Helvetica" font-size="16px">
+                    Now that we know how information gets in and out of our system, we can start to look at org...
+                </text>
+            </switch>
+        </g>
+        <rect x="20" y="3283" width="110" height="50" fill="#000000" stroke="#000000" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="20" y="3283" width="110" height="50" fill="#f99e4c" stroke="#f99e4c" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 3308px; margin-left: 21px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                <font style="font-size: 18px">
+                                    Event
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="3315" fill="#000000" font-family="Helvetica" font-size="22px" text-anchor="middle">
+                    Event
+                </text>
+            </switch>
+        </g>
+        <path d="M 30.5 3364 L 30.5 3362 L 80 3362 L 105.17 3362 L 105.17 3358.83 L 119.5 3363 L 105.17 3367.17 L 105.17 3364 L 80 3364 Q 80 3364 80 3364 Z" fill="#000000" stroke="#000000" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 105.17 3362 L 105.17 3358.83 L 119.5 3363 L 105.17 3367.17 L 105.17 3364" fill="none" stroke="#000000" stroke-linejoin="flat" stroke-miterlimit="4" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 3363px; margin-left: 76px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #F3F3F3; white-space: nowrap; ">
+                                 Timeline 
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="76" y="3367" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                     Timeline 
+                </text>
+            </switch>
+        </g>
+        <image x="43.5" y="3402.5" width="62" height="62" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGFyaWEtaGlkZGVuPSJ0cnVlIiBmb2N1c2FibGU9ImZhbHNlIiBkYXRhLXByZWZpeD0iZmFzIiBkYXRhLWljb249ImNvZyIgY2xhc3M9InN2Zy1pbmxpbmUtLWZhIGZhLWNvZyBmYS13LTE2IiByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBmaWxsPSJjdXJyZW50Q29sb3IiIGQ9Ik00ODcuNCAzMTUuN2wtNDIuNi0yNC42YzQuMy0yMy4yIDQuMy00NyAwLTcwLjJsNDIuNi0yNC42YzQuOS0yLjggNy4xLTguNiA1LjUtMTQtMTEuMS0zNS42LTMwLTY3LjgtNTQuNy05NC42LTMuOC00LjEtMTAtNS4xLTE0LjgtMi4zTDM4MC44IDExMGMtMTcuOS0xNS40LTM4LjUtMjcuMy02MC44LTM1LjFWMjUuOGMwLTUuNi0zLjktMTAuNS05LjQtMTEuNy0zNi43LTguMi03NC4zLTcuOC0xMDkuMiAwLTUuNSAxLjItOS40IDYuMS05LjQgMTEuN1Y3NWMtMjIuMiA3LjktNDIuOCAxOS44LTYwLjggMzUuMUw4OC43IDg1LjVjLTQuOS0yLjgtMTEtMS45LTE0LjggMi4zLTI0LjcgMjYuNy00My42IDU4LjktNTQuNyA5NC42LTEuNyA1LjQuNiAxMS4yIDUuNSAxNEw2Ny4zIDIyMWMtNC4zIDIzLjItNC4zIDQ3IDAgNzAuMmwtNDIuNiAyNC42Yy00LjkgMi44LTcuMSA4LjYtNS41IDE0IDExLjEgMzUuNiAzMCA2Ny44IDU0LjcgOTQuNiAzLjggNC4xIDEwIDUuMSAxNC44IDIuM2w0Mi42LTI0LjZjMTcuOSAxNS40IDM4LjUgMjcuMyA2MC44IDM1LjF2NDkuMmMwIDUuNiAzLjkgMTAuNSA5LjQgMTEuNyAzNi43IDguMiA3NC4zIDcuOCAxMDkuMiAwIDUuNS0xLjIgOS40LTYuMSA5LjQtMTEuN3YtNDkuMmMyMi4yLTcuOSA0Mi44LTE5LjggNjAuOC0zNS4xbDQyLjYgMjQuNmM0LjkgMi44IDExIDEuOSAxNC44LTIuMyAyNC43LTI2LjcgNDMuNi01OC45IDU0LjctOTQuNiAxLjUtNS41LS43LTExLjMtNS42LTE0LjF6TTI1NiAzMzZjLTQ0LjEgMC04MC0zNS45LTgwLTgwczM1LjktODAgODAtODAgODAgMzUuOSA4MCA4MC0zNS45IDgwLTgwIDgweiIvPjwvc3ZnPg==" preserveAspectRatio="none"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
+            <rect fill="#F3F3F3" stroke="none" x="48" y="3473" width="56" height="15" stroke-width="0"/>
+            <text x="74.5" y="3482.5">
+                Processor
+            </text>
+        </g>
+        <path d="M 55 3518 C 55 3515.24 57.24 3513 60 3513 L 90 3513 C 92.76 3513 95 3515.24 95 3518 L 95 3588 C 95 3590.76 92.76 3593 90 3593 L 60 3593 C 57.24 3593 55 3590.76 55 3588 Z" fill="none" stroke="#c0c0c0" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="75" cy="3516.6" rx="0.5" ry="0.5" fill="none" stroke="#c0c0c0" pointer-events="all"/>
+        <rect x="57.5" y="3525" width="35" height="56" fill="none" stroke="#c0c0c0" pointer-events="all"/>
+        <path d="M 70 3519.8 C 70 3519.59 70.08 3519.38 70.23 3519.23 C 70.38 3519.08 70.59 3519 70.8 3519 L 79.2 3519 C 79.41 3519 79.62 3519.08 79.77 3519.23 C 79.92 3519.38 80 3519.59 80 3519.8 C 80 3520.01 79.92 3520.22 79.77 3520.37 C 79.62 3520.52 79.41 3520.6 79.2 3520.6 L 70.8 3520.6 C 70.59 3520.6 70.38 3520.52 70.23 3520.37 C 70.08 3520.22 70 3520.01 70 3519.8 Z" fill="none" stroke="#c0c0c0" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="75" cy="3587" rx="4" ry="4" fill="none" stroke="#c0c0c0" pointer-events="all"/>
+        <path d="M 73.3 3585.9 C 73.3 3585.62 73.52 3585.4 73.8 3585.4 L 76.2 3585.4 C 76.48 3585.4 76.7 3585.62 76.7 3585.9 L 76.7 3588.3 C 76.7 3588.58 76.48 3588.8 76.2 3588.8 L 73.8 3588.8 C 73.52 3588.8 73.3 3588.58 73.3 3588.3 Z" fill="none" stroke="#c0c0c0" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 3600px; margin-left: 75px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #F3F3F3; white-space: nowrap; ">
+                                User Interface
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="3612" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    User I...
+                </text>
+            </switch>
+        </g>
+        <rect x="20" y="3633" width="110" height="50" fill="#000000" stroke="#000000" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="20" y="3633" width="110" height="50" fill="#35c4e8" stroke="#35c4e8" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 3658px; margin-left: 21px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                <font style="font-size: 18px">
+                                    Command
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="3665" fill="#000000" font-family="Helvetica" font-size="22px" text-anchor="middle">
+                    Command
+                </text>
+            </switch>
+        </g>
+        <rect x="20" y="3703" width="110" height="50" fill="#000000" stroke="#000000" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="20" y="3703" width="110" height="50" fill="#d4e384" stroke="#d4e384" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 3728px; margin-left: 21px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 22px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                <font style="font-size: 18px">
+                                    Read
+                                    <br/>
+                                    Model
+                                    <br/>
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="75" y="3735" fill="#000000" font-family="Helvetica" font-size="22px" text-anchor="middle">
+                    Read...
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://desk.draw.io/support/solutions/articles/16000042487" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Viewer does not support full SVG 1.1
+            </text>
+        </a>
+    </switch>
+</svg>


### PR DESCRIPTION
This PR adds a draw.io SVG template.

The template consists of several layers each of which can be locked or hidden:

- `Template`: The grid layout for the steps
- `Instructions Step 1` - `Instructions Step 6`: The instructions for each step - can be hidden when working in a particular step
- `Modeling Step 1` - `Modeling Step 6`: Contains the draggable `Legend` elements for each step