### PR TITLE
Remove quote from link

### DIFF
--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -64,7 +64,7 @@ This is a discussion with Roy Osherove about Event Modeling and Event Sourcing. 
 # [Tools](#tools) {#tools}
 
 ## Online Modeling Tools:
-### [Modellution (Beta)](https://www.modellution.com")
+### [Modellution (Beta)](https://www.modellution.com)
 
 **Modellution** is a web platform designed for modeling information systems. It allows real-time visual collaboration, estimates, Jira & ClickUp integrations, and code-generation.
 There's free commercial version available.


### PR DESCRIPTION
Just saw while perusing.

The quote in the link causes (at least in Firefox) a `%22` to be appended to the URL, which actually then renders the link un-clickable.